### PR TITLE
Change key from `redshift` to `tile-history` to match the code.

### DIFF
--- a/templates/default/tilequeue-config.yaml.erb
+++ b/templates/default/tilequeue-config.yaml.erb
@@ -112,7 +112,7 @@ metatile:
 <%- end -%>
 <%- if node[:tilequeue][:toiprune][:enabled] -%>
 toi-prune:
-  redshift:
+  tile-history:
     database-uri: <%= node[:tilequeue][:toiprune][:redshift][:database_uri] %>
     days: <%= node[:tilequeue][:toiprune][:redshift][:days] %>
     max-zoom: <%= node[:tilequeue][:toiprune][:redshift][:max_zoom] %>


### PR DESCRIPTION
The code uses [`tile-history`](https://github.com/tilezen/tilequeue/blob/3c728e6f0533fe969f36e051fa79dbe70f97fcab/tilequeue/command.py#L1067), so the config results in an assertion triggering and halting the process.