### PR TITLE
Patch release to correct key for prune operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.12.1
+------
+
+* Change key from `redshift` to `tile-history` to match the code.
+* Configure yaml parsing for python output functions
+
 0.12.0
 ------
 * Add chef support for toi-store configuration

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rob@mapzen.com'
 license          'GPL v3'
 description      'Installs/Configures tilequeue'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.0'
+version          '0.12.1'
 
 recipe 'tilequeue', 'Installs tilequeue'
 


### PR DESCRIPTION
Note that I typo'ed the branch name - this is `0.12.1` not `0.12.0`, since the latter already exists.