### PR TITLE
Bump dependency versions installed by pip.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,32 +17,32 @@ default[:tilequeue][:revision][:tilequeue] = 'master'
 
 default[:tilequeue][:pip_requirements] = %w(
   appdirs==1.4.3
-  argparse==1.2.1
-  boto==2.33.0
-  future==0.15.2
+  argparse==1.4.0
+  boto==2.48.0
+  enum34==1.1.6
+  future==0.16.0
   hiredis==0.2.0
-  Jinja2==2.8
-  MarkupSafe==0.23
-  ModestMaps==1.4.6
-  protobuf==2.6.0
-  psycopg2==2.5.4
-  pyclipper==1.0.5
-  pycountry==1.20
+  Jinja2==2.9.6
+  MarkupSafe==1.0
+  ModestMaps==1.4.7
+  protobuf==3.4.0
+  psycopg2==2.7.3.2
+  pyclipper==1.0.6
+  pycountry==17.9.23
   pyproj==1.9.5.1
-  python-dateutil==2.4.2
-  PyYAML==3.11
-  redis==2.10.5
-  requests==2.10.0
-  Shapely==1.4.3
-  simplejson==3.6.4
-  six==1.10.0
+  python-dateutil==2.6.1
+  PyYAML==3.12
+  redis==2.10.6
+  requests==2.18.4
+  Shapely==1.6.2.post1
+  six==1.11.0
   StreetNames==0.1.5
   statsd==3.2.1
   ujson==1.35
-  Werkzeug==0.9.6
+  Werkzeug==0.12.2
   wsgiref==0.1.2
-  zope.dottedname==4.1.0
-  git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
+  zope.dottedname==4.2
+  edtf==2.6.0
 )
 
 default[:tilequeue][:pip_requirements] += [

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rob@mapzen.com'
 license          'GPL v3'
 description      'Installs/Configures tilequeue'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.1'
+version          '0.12.2'
 
 recipe 'tilequeue', 'Installs tilequeue'
 


### PR DESCRIPTION
This now matches the `requirements.txt` file in the current master repo, apart from `mapbox-vector-tile`, which has been kept as an overridable git branch/tag/commit.

This is needed because the master branch of `tilequeue` has been updated to the latest version of the EDTF library, which has a slightly different interface to the raw git commit that we were using here before.